### PR TITLE
Update rlmaws.services.yml

### DIFF
--- a/modules/util/aws/rlmaws.services.yml
+++ b/modules/util/aws/rlmaws.services.yml
@@ -1,4 +1,4 @@
-service:
+services:
   rlmaws.client_factory:
     class: 'Drupal\rlmaws\AWSClientFactory'
     arguments: [ '@config_factory', '@rlmaws.credential_provider' ]


### PR DESCRIPTION
## Motivation
I get an error when trying to enable AWS module,
## Resolution
Declared services have to be under 'services' instead of 'service'.