### PR TITLE
CK-34975 Error when trying to add relationship to a layout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
               "Configurable Component Variables": "https://www.drupal.org/files/issues/2916331-11.patch"
           },
           "drupal/ctools": {
-              "Fix TypedData Relationship Deriver": "https://www.drupal.org/files/issues/2018-10-16/3007028-2.patch"
+              "Fix TypedData Relationship Deriver": "https://www.drupal.org/files/issues/2018-10-16/3007028-2.patch",
+              "Fix Label for Context Definition in Relationship Deriver": "https://www.drupal.org/files/issues/2019-09-03/3079000-2.patch"
           },
           "drupal/decoupled_auth": {
               "Allow unsaved profiles": "https://www.drupal.org/files/issues/2019-08-13/3058223-4.patch"


### PR DESCRIPTION
## Motivation
The label argument passed to ContextDefinition no longer supports DataDefinition, which throws the following error:

Recoverable fatal error: Object of class Drupal\Core\Entity\TypedData\EntityDataDefinition could not be converted to string in Drupal\Component\Utility\Xss::filter()

## Resolution
Update the argument to be just 'Base'. 
## Links
https://jira.counselnow.com/browse/CK-34975

Drupal Issue: https://www.drupal.org/project/ctools/issues/3079000#comment-13245348