### PR TITLE
CK-36480 by KGZ: Updated patch for fixing label in relationship deriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
           },
           "drupal/ctools": {
               "Fix TypedData Relationship Deriver": "https://www.drupal.org/files/issues/2018-10-16/3007028-2.patch",
-              "Fix Label for Context Definition in Relationship Deriver": "https://www.drupal.org/files/issues/2019-09-03/3079000-2.patch"
+              "Fix Label for Context Definition in Relationship Deriver": "https://www.drupal.org/files/issues/2019-10-24/3079000-4.patch"
           },
           "drupal/decoupled_auth": {
               "Allow unsaved profiles": "https://www.drupal.org/files/issues/2019-09-12/3058223-5.patch"


### PR DESCRIPTION
## Motivation
The previous patch file was wrongly created so it failed to apply.
## Resolution
Created new patch that is working and added it to the composer file.
- composer.json
## Links
https://jira.counselnow.com/browse/CK-36480