### PR TITLE
CK-38521 Removed broken update function

### DIFF
--- a/modules/data/identity/identity.install
+++ b/modules/data/identity/identity.install
@@ -104,16 +104,3 @@ function identity_update_8006() {
       ->setDisplayConfigurable('view', TRUE)
   );
 }
-
-/**
- * Add value index to full name field.
- */
-function identity_update_8007() {
-  $updater = \Drupal::entityDefinitionUpdateManager();
-  $def = $updater->getFieldStorageDefinition('full_name', 'identity_data');
-  $def = BundleFieldDefinition::createFromFieldStorageDefinition($def);
-  $def->setIndexes([
-    'value' => ['value'],
-  ]);
-  $updater->updateFieldStorageDefinition($def);
-}


### PR DESCRIPTION
## Motivation
This function throws the following error:
[ERROR] The SQL storage cannot change the schema for an existing field (full_name in identity_data entity) with data.
We need to get rid of it as it's not needed.
## Resolution
Removed function.
- modules/data/identity/identity.install
## Links
https://jira.counselnow.com/browse/CK-38521