### PR TITLE
CK-39644 Add add form template link to document in document_ui

### DIFF
--- a/modules/data/document/contrib/ui/document_ui.module
+++ b/modules/data/document/contrib/ui/document_ui.module
@@ -13,9 +13,10 @@ function document_ui_entity_type_build(array &$entity_types) {
       'route_provider',
       [
         'html' => DefaultHtmlRouteProvider::class,
-      ] + $type->getHandlerClass('route_provider')
+      ] + ($type->getHandlerClass('route_provider') ?: [])
     );
 
+    $type->setLinkTemplate('add-form', '/document/add');
     $type->setLinkTemplate('canonical', '/document/{document}');
     $type->setLinkTemplate('edit-form', '/document/{document}/edit');
   }


### PR DESCRIPTION
## Motivation
The document ui has the canonical and the edit links but it's missing the add form link, which can be useful to draft documents.
## Resolution
Added link in module file.
- modules/data/document/contrib/ui/document_ui.module
## Links
https://jira.counselnow.com/browse/CK-39644
