### PR TITLE
CK-39732 Update install function for pdf_style and pdf_content fields, and default value for is_archived field

### DIFF
--- a/modules/data/document/contrib/generation/document_generation.install
+++ b/modules/data/document/contrib/generation/document_generation.install
@@ -7,20 +7,25 @@ use Drupal\entity\BundleFieldDefinition;
  * Implements hook_install().
  */
 function document_generation_install() {
-  $updater = \Drupal::entityDefinitionUpdateManager();
-  $updater->installFieldStorageDefinition(
-    'pdf_style',
-    'document',
-    'document_generation',
-    BundleFieldDefinition::create('entity_reference')
-      ->setLabel(new TranslatableMarkup('Style'))
-      ->setSetting('target_type', 'pdf_style')
-  );
-  $updater->installFieldStorageDefinition(
-    'pdf_content',
-    'document',
-    'document_generation',
-    BundleFieldDefinition::create('text_long')
-      ->setLabel(new TranslatableMarkup('Content'))
-  );
+  /** @var \Drupal\Core\Field\FieldStorageDefinitionListenerInterface $field_storage_definition_listener */
+  $field_storage_definition_listener = \Drupal::service('field_storage_definition.listener');
+  /** @var \Drupal\Core\Field\FieldDefinitionListenerInterface $field_definition_listener */
+  $field_definition_listener = \Drupal::service('field_definition.listener');
+
+  $fields = [];
+  $fields['pdf_style'] = BundleFieldDefinition::create('entity_reference')
+    ->setLabel(new TranslatableMarkup('Style'))
+    ->setSetting('target_type', 'pdf_style');
+  $fields['pdf_content'] = BundleFieldDefinition::create('text_long')
+    ->setLabel(new TranslatableMarkup('Content'));
+
+  foreach ($fields as $name => $definition) {
+    /** @var \Drupal\entity\BundleFieldDefinition $definition */
+    $definition->setName($name);
+    $definition->setTargetEntityTypeId('document');
+    $definition->setProvider('document_generation');
+
+    $field_storage_definition_listener->onFieldStorageDefinitionCreate($definition);
+    $field_definition_listener->onFieldDefinitionCreate($definition);
+  }
 }

--- a/modules/data/document/src/Entity/Document.php
+++ b/modules/data/document/src/Entity/Document.php
@@ -88,7 +88,7 @@ class Document extends ContentEntityBase implements EntityOwnerInterface, Entity
     $fields['is_archived'] = BaseFieldDefinition::create('boolean')
       ->setLabel(new TranslatableMarkup('Archived?'))
       ->setRevisionable(TRUE)
-      ->setDefaultValue(TRUE)
+      ->setDefaultValue(FALSE)
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'settings' => [


### PR DESCRIPTION
## Motivation
We need to use field storage definition and field storage listeners to install bundle field definitions.
## Resolution
Updated install function.
- modules/data/document/contrib/generation/document_generation.install

Updated the default value for is_archived field to FALSE.
- modules/data/document/src/Entity/Document.php
## Links
https://jira.counselnow.com/browse/CK-39732