### PR TITLE
CK-39809 Register document generation service and add worflow setting to state field.

### DIFF
--- a/modules/data/document/contrib/generation/document_generation.module
+++ b/modules/data/document/contrib/generation/document_generation.module
@@ -51,3 +51,12 @@ function document_generation_entity_field_storage_info(EntityTypeInterface $enti
 
   return $storages;
 }
+
+/**
+ * Implements hook_entity_base_field_info_alter().
+ */
+function document_generation_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
+  if ($entity_type->id() == 'document' && !empty($fields['state'])) {
+    $fields['state']->setSetting('workflow', 'generation');
+  }
+}

--- a/modules/data/document/contrib/generation/document_generation.services.yml
+++ b/modules/data/document/contrib/generation/document_generation.services.yml
@@ -1,0 +1,6 @@
+services:
+  document_generation.pdf_generation_subscriber:
+    class: Drupal\document_generation\EventSubscriber\DocumentPDFGenerationSubscriber
+    arguments: ['@pdf_tools.generator', '@entity_type.manager', '@file.mime_type.guesser', '@file_system']
+    tags:
+      - {name: event_subscriber }

--- a/modules/data/document/contrib/generation/src/EventSubscriber/DocumentPDFGenerationSubscriber.php
+++ b/modules/data/document/contrib/generation/src/EventSubscriber/DocumentPDFGenerationSubscriber.php
@@ -73,7 +73,7 @@ class DocumentPDFGenerationSubscriber implements EventSubscriberInterface {
       'pdf_style' => $document->pdf_style->entity,
       '__destination' => $field_def->getSetting('uri_scheme', 'private'). '://'
         . $field_def->getSetting('file_directory', 'documents')
-        . '/' . preg_replace('/[^A-z0-9_]+/', '-', $document->label->value) . '.pdf',
+        . '/' . preg_replace('/[^a-z0-9_-]+/i', '-', $document->label->value) . '.pdf',
     ];
 
     $uri = $this->generator->renderArrayToPDF(

--- a/modules/data/document/contrib/generation/src/EventSubscriber/DocumentPDFGenerationSubscriber.php
+++ b/modules/data/document/contrib/generation/src/EventSubscriber/DocumentPDFGenerationSubscriber.php
@@ -73,10 +73,10 @@ class DocumentPDFGenerationSubscriber implements EventSubscriberInterface {
       'pdf_style' => $document->pdf_style->entity,
       '__destination' => $field_def->getSetting('uri_scheme', 'private'). '://'
         . $field_def->getSetting('file_directory', 'documents')
-        . '/' . preg_replace('[^a-z0-9_-]+', '-', $document->label->value) . '.pdf',
+        . '/' . preg_replace('/[^A-z0-9_]+/', '-', $document->label->value) . '.pdf',
     ];
 
-    $uri = $this->generator->generateFromHTML(
+    $uri = $this->generator->renderArrayToPDF(
       $document->pdf_content->view([
         'type' => 'text_default',
         'label' => 'hidden',
@@ -96,6 +96,7 @@ class DocumentPDFGenerationSubscriber implements EventSubscriberInterface {
 
     $this->fileSystem->chmod($file->getFileUri());
     $file->save();
-
+    $document->file = $file;
   }
+
 }

--- a/modules/data/document/contrib/workflow/document_workflow.module
+++ b/modules/data/document/contrib/workflow/document_workflow.module
@@ -13,7 +13,6 @@ function document_workflow_entity_base_field_info(EntityTypeInterface $entity_ty
   if ($entity_type->id() === 'document') {
     $fields['state'] = BaseFieldDefinition::create('state')
       ->setLabel(new TranslatableMarkup('Status'))
-      ->setSetting('workflow', 'generation')
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
 

--- a/modules/data/document/contrib/workflow/document_workflow.module
+++ b/modules/data/document/contrib/workflow/document_workflow.module
@@ -13,6 +13,7 @@ function document_workflow_entity_base_field_info(EntityTypeInterface $entity_ty
   if ($entity_type->id() === 'document') {
     $fields['state'] = BaseFieldDefinition::create('state')
       ->setLabel(new TranslatableMarkup('Status'))
+      ->setSetting('workflow', 'generation')
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
 


### PR DESCRIPTION
## Motivation
The document generation service is not enabled, and we need it to generate the pdf file while transitioning. Also the state field doesn't have a workflow setting so there's no transitions available for it.
## Resolution
Register service.
- modules/data/document/contrib/generation/document_generation.services.yml

Added workflow setting to state field.
- modules/data/document/contrib/workflow/document_workflow.module

Minor fixes to pdf generation subscriber.
- modules/data/document/contrib/generation/src/EventSubscriber/DocumentPDFGenerationSubscriber.php
## Links
https://jira.counselnow.com/browse/CK-39809